### PR TITLE
Change /weatherman command and gear button in /xlplugins to toggle instead of just open config like most plugins do

### DIFF
--- a/Weatherman/Weatherman.csproj
+++ b/Weatherman/Weatherman.csproj
@@ -49,10 +49,6 @@
 			<HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<Reference Include="ImGuiScene">
-			<HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
 		<Reference Include="Lumina">
 			<HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
 			<Private>False</Private>

--- a/Weatherman/WeathermanPlugin/Weatherman.cs
+++ b/Weatherman/WeathermanPlugin/Weatherman.cs
@@ -110,10 +110,10 @@ namespace Weatherman
                 Svc.Framework.Update += HandleFrameworkUpdate;
                 ConfigGui = new(this);
                 Svc.PluginInterface.UiBuilder.Draw += ConfigGui.Draw;
-                Svc.PluginInterface.UiBuilder.OpenConfigUi += delegate { ConfigGui.configOpen = true; };
+                Svc.PluginInterface.UiBuilder.OpenConfigUi += delegate { ConfigGui.configOpen = !ConfigGui.configOpen ? true : false; };
                 Svc.ClientState.TerritoryChanged += HandleZoneChange;
                 ApplyWeatherChanges(Svc.ClientState.TerritoryType);
-                Svc.Commands.AddHandler("/weatherman", new CommandInfo(delegate { ConfigGui.configOpen = true; }) { HelpMessage = "Open plugin settings" });
+                Svc.Commands.AddHandler("/weatherman", new CommandInfo(delegate { ConfigGui.configOpen = !ConfigGui.configOpen ? true : false; }) { HelpMessage = "Toggle plugin settings" });
                 /*if (ChlogGui.ChlogVersion > configuration.ChlogReadVer)
                 {
                     new ChlogGui(this);


### PR DESCRIPTION
Hello! I've been setting up all the plugins that I want easy access to on a QoLBar at the bottom of my screen like in the screenshot below. Most of them will toggle a window open or closed, but some plugins, such as Weatherman just open it and don't close when I click on it and the window is already opened. This PR changes it to a toggle.

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/3673962/167543607-2783e771-c502-46a7-be37-73bbff3a60ee.png">

I also snuck in a removal of some lines of code that the Dalamud linter recommended to remove.

One more thing, I couldn't seem to load the plugin when I built on "Release", but when I built on any new "solution configuration" in Visual Studio, it seemed to work. In the end, I decided not to commit my changes for that since I assume you may have something already working for you on your end.